### PR TITLE
Use better name for bandit config to use it by the codacy

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,4 +1,0 @@
-[bandit]
-skips: B101
-exclude: /docs
-

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: check-code-style check-pylint check-bandit
+
+check-code-style: check-pylint check-bandit
+
+check-pylint:
+	pylint tool || true
+
+check-bandit:
+	bandit . -r -c bandit.yml || true
+

--- a/bandit.yml
+++ b/bandit.yml
@@ -1,0 +1,8 @@
+skips:
+    - B101
+    - B404
+    - B603
+    - B606
+    - B607
+exclude: /docs
+


### PR DESCRIPTION
Use codacy-recognisable name for bandit config

Signed-off-by: lachmanfrantisek <flachman@redhat.com>