### PR TITLE
Add support for the label listing

### DIFF
--- a/tool/cli.py
+++ b/tool/cli.py
@@ -99,7 +99,7 @@ def list_branches():
     print(tabulate(a.list_branches(), tablefmt="fancy_grid"))
 
 
-@click.command(name="list_labels",
+@click.command(name="list-labels",
                help="List labels for the project. "
                     "This is how you can select a repository for Github: <namespace>/<project>.")
 @click.option('--service', "-s", type=click.STRING, default="github",
@@ -109,12 +109,12 @@ def list_labels(service, repo):
     """
     List the labels for the selected repository, default to repo in $PWD
     """
-    a = App()
+    app = App()
     if repo:
-        s = a.get_service(service, repo=repo)
+        serv = app.get_service(service, repo=repo)
     else:
-        s = a.guess_service()
-    repo_labels = s.list_labels()
+        serv = app.guess_service()
+    repo_labels = serv.list_labels()
     if not repo_labels:
         print("No labels.")
         return
@@ -128,31 +128,33 @@ def list_labels(service, repo):
     ], tablefmt="fancy_grid"))
 
 
-@click.command(name="update_labels",
+@click.command(name="update-labels",
                help="Update labels of other project. "
                     "Multiple destinations can be set by joining them with semicolon. "
                     "This is how you can select a repository for Github: <namespace>/<project>.")
 @click.option('--service', "-s", type=click.STRING, default="github",
+              help="Name of the git service for destination (e.g. github/gitlab).")
+@click.option('--source-service', type=click.STRING, default="github",
               help="Name of the git service (e.g. github/gitlab).")
 @click.argument('destination', type=click.STRING)
 @click.argument('source', type=click.STRING, required=False)
-def update_labels(service, destination, source):
+def update_labels(service, source_service, destination, source):
     """
     List the labels for the selected repository, default to repo in $PWD
     """
-    a = App()
+    app = App()
     if source:
-        s = a.get_service(service, repo=source)
+        serv = app.get_service(source_service, repo=source)
     else:
-        s = a.guess_service()
-    repo_labels = s.list_labels()
+        serv = app.guess_service()
+    repo_labels = serv.list_labels()
     if not repo_labels:
         print("No labels.")
         return
 
     dest_repos = destination.split(';')
     for repo_for_copy in dest_repos:
-        other_serv = a.get_service(service, repo=repo_for_copy)
+        other_serv = app.get_service(service, repo=repo_for_copy)
         changes = other_serv.update_labels(labels=repo_labels)
 
         click.echo("{changes} labels of {labels_count} copied to {repo_name}".format(

--- a/tool/cli.py
+++ b/tool/cli.py
@@ -108,7 +108,7 @@ def list_branches():
 @click.option('--copy', '-c', type=click.STRING, required=False, multiple=True,
               help="Copy labels to another repo.")
 @click.argument('repo', type=click.STRING, required=False)
-def labels(service, forward, repo):
+def labels(service, copy, repo):
     """
     List the labels for the selected repository, default to repo in $PWD
     """
@@ -117,8 +117,8 @@ def labels(service, forward, repo):
         s = a.get_service(service, repo=repo)
     else:
         s = a.guess_service()
-    labels = s.list_labels()
-    if not labels:
+    repo_labels = s.list_labels()
+    if not repo_labels:
         print("No labels requests.")
         return
     print(tabulate([
@@ -127,14 +127,18 @@ def labels(service, forward, repo):
             label.color,
             label.description
         )
-        for label in labels
+        for label in repo_labels
     ], tablefmt="fancy_grid"))
 
-    for f in forward:
-        s = a.get_service(service, repo=f)
-        changes = s.update_labels(labels=labels)
+    for repo_for_copy in copy:
+        other_serv = a.get_service(service, repo=repo_for_copy)
+        changes = other_serv.update_labels(labels=repo_labels)
 
-        click.echo(f"{changes} labels of {len(labels)} copied to {f}")
+        click.echo("{changes} labels of {labels_count} copied to {repo_name}".format(
+            changes=changes,
+            labels_count=len(repo_labels),
+            repo_name=repo_for_copy
+        ))
 
 
 tool.add_command(fork)

--- a/tool/cli.py
+++ b/tool/cli.py
@@ -132,19 +132,19 @@ def list_labels(service, repo):
                help="Update labels of other project. "
                     "Multiple destinations can be set by joining them with semicolon. "
                     "This is how you can select a repository for Github: <namespace>/<project>.")
-@click.option('--service', "-s", type=click.STRING, default="github",
-              help="Name of the git service for destination (e.g. github/gitlab).")
+@click.option('--source-repo', '-r', type=click.STRING)
 @click.option('--source-service', type=click.STRING, default="github",
               help="Name of the git service (e.g. github/gitlab).")
-@click.argument('destination', type=click.STRING)
-@click.argument('source', type=click.STRING, required=False)
-def update_labels(service, source_service, destination, source):
+@click.option('--service', "-s", type=click.STRING, default="github",
+              help="Name of the git service for destination (e.g. github/gitlab).")
+@click.argument('destination', type=click.STRING, nargs=-1)
+def update_labels(source_repo, service, source_service, destination):
     """
     List the labels for the selected repository, default to repo in $PWD
     """
     app = App()
-    if source:
-        serv = app.get_service(source_service, repo=source)
+    if source_repo:
+        serv = app.get_service(source_service, repo=source_repo)
     else:
         serv = app.guess_service()
     repo_labels = serv.list_labels()
@@ -152,8 +152,7 @@ def update_labels(service, source_service, destination, source):
         print("No labels.")
         return
 
-    dest_repos = destination.split(';')
-    for repo_for_copy in dest_repos:
+    for repo_for_copy in destination:
         other_serv = app.get_service(service, repo=repo_for_copy)
         changes = other_serv.update_labels(labels=repo_labels)
 

--- a/tool/services/github_service.py
+++ b/tool/services/github_service.py
@@ -119,6 +119,11 @@ class GithubService(Service):
         return pr.html_url
 
     def list_pull_requests(self):
+        """
+        Get list of pull-requests for the repository.
+
+        :return: [PullRequest]
+        """
         prs = self.repo.get_pulls(state="open",
                                   sort="updated",
                                   direction="desc")
@@ -132,16 +137,26 @@ class GithubService(Service):
             for pr in prs]
 
     def list_labels(self):
+        """
+        Get list of labels in the repository.
+        :return: [Label]
+        """
         return list(self.repo.get_labels())
 
     def update_labels(self, labels):
+        """
+        Update the labels of the repository. (No deletion, only add not existing ones.)
+
+        :param labels: [str]
+        :return: int - number of added labels
+        """
         current_label_names = [l.name for l in list(self.repo.get_labels())]
         changes = 0
-        for l in labels:
-            if l.name not in current_label_names:
-                self.repo.create_label(name=l.name,
-                                       color=l.color,
-                                       description=l.description or "")
+        for label in labels:
+            if label.name not in current_label_names:
+                self.repo.create_label(name=label.name,
+                                       color=label.color,
+                                       description=label.description or "")
 
                 changes += 1
         return changes

--- a/tool/services/github_service.py
+++ b/tool/services/github_service.py
@@ -154,9 +154,16 @@ class GithubService(Service):
         changes = 0
         for label in labels:
             if label.name not in current_label_names:
+                color = self._normalize_label_color(color=label.color)
                 self.repo.create_label(name=label.name,
-                                       color=label.color,
+                                       color=color,
                                        description=label.description or "")
 
                 changes += 1
         return changes
+
+    @staticmethod
+    def _normalize_label_color(color):
+        if color.startswith('#'):
+            return color[1:]
+        return color

--- a/tool/services/github_service.py
+++ b/tool/services/github_service.py
@@ -130,3 +130,18 @@ class GithubService(Service):
                 'url': pr.html_url,
             }
             for pr in prs]
+
+    def list_labels(self):
+        return list(self.repo.get_labels())
+
+    def update_labels(self, labels):
+        current_label_names = [l.name for l in list(self.repo.get_labels())]
+        changes = 0
+        for l in labels:
+            if l.name not in current_label_names:
+                self.repo.create_label(name=l.name,
+                                       color=l.color,
+                                       description=l.description or "")
+
+                changes += 1
+        return changes

--- a/tool/services/gitlab_service.py
+++ b/tool/services/gitlab_service.py
@@ -109,9 +109,16 @@ class GitlabService(Service):
         changes = 0
         for label in labels:
             if label.name not in current_label_names:
+                color = self._normalize_label_color(color=label.color)
                 self.repo.labels.create({'name': label.name,
-                                         'color': label.color,
+                                         'color': color,
                                          'description': label.description or ""})
 
                 changes += 1
         return changes
+
+    @staticmethod
+    def _normalize_label_color(color):
+        if not color.startswith('#'):
+            return '#{}'.format(color)
+        return color


### PR DESCRIPTION
- Add listing labels with ability to copy them to other repo.


```
Usage: tool labels [OPTIONS] [REPO]

  List the labels for the project. This is how you can select a repository
  for Github: <namespace>/<project>.

Options:
  -s, --service TEXT  Name of the git service (e.g. github/gitlab).
  -c, --copy TEXT     Copy labels to another repo.
  --help              Show this message and exit.
```


```
$ tool labels -c user-cont/colin -c user-cont/conu
╒══════════════════════════════════╤════════╤══╕
│ bug                              │ d73a4a │  │
├──────────────────────────────────┼────────┼──┤
│ duplicate                        │ cfd3d7 │  │
├──────────────────────────────────┼────────┼──┤
│ enhancement                      │ a2eeef │  │
├──────────────────────────────────┼────────┼──┤
│ good first issue                 │ 7057ff │  │
├──────────────────────────────────┼────────┼──┤
│ help wanted                      │ 008672 │  │
├──────────────────────────────────┼────────┼──┤
│ invalid                          │ e4e669 │  │
├──────────────────────────────────┼────────┼──┤
│ label-for-testing-the-label-sync │ 0e8a16 │  │
├──────────────────────────────────┼────────┼──┤
│ question                         │ d876e3 │  │
├──────────────────────────────────┼────────┼──┤
│ wontfix                          │ ffffff │  │
╘══════════════════════════════════╧════════╧══╛
1 labels of 9 moved to user-cont/colin
1 labels of 9 moved to user-cont/conu
```